### PR TITLE
Set up SecuriBench tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target/*
+*.pdg

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ library and configure it as a local maven dependency.
 
 Currently, you might run the 'securibench' benchmark using JUnit test cases. Such as:
 
-   * Basic test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.BasicTestSuite"`
    * Aliasing test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.AliasingTestSuite`
+   * Array test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.ArrayTestSuite"`
+   * Basic test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.BasicTestSuite"`
+   * Collection test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.CollectionTestSuite`
+   * Datastructure test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.DatastructureTestSuite"`
+   * Factory test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.FactoryTestSuite`
+   * Session test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.SessionTestSuite"`
+   * StrongUpdate test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.StrongUpdateTestSuite`
    

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ library and configure it as a local maven dependency.
 
 Currently, you might run the 'securibench' benchmark using JUnit test cases. Such as:
 
-   * Aliasing test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.AliasingTestSuite`
+   * Aliasing test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.AliasingTestSuite"`
    * Array test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.ArrayTestSuite"`
    * Basic test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.BasicTestSuite"`
-   * Collection test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.CollectionTestSuite`
+   * Collection test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.CollectionTestSuite"`
    * Datastructure test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.DatastructureTestSuite"`
-   * Factory test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.FactoryTestSuite`
+   * Factory test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.FactoryTestSuite"`
    * Session test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.SessionTestSuite"`
-   * StrongUpdate test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.StrongUpdateTestSuite`
+   * StrongUpdate test suite: `mvn test -Dtest="br.unb.cic.joana.securibench.micro.suite.StrongUpdateTestSuite"`
    

--- a/src/test/java/br/unb/cic/joana/JoanaTestCase.java
+++ b/src/test/java/br/unb/cic/joana/JoanaTestCase.java
@@ -38,6 +38,7 @@ public abstract class JoanaTestCase extends TestCase {
 
         return config;
     }
+
     protected Driver driver;
 
     public void setUpConfiguration(String entryPointMethod) throws Exception {
@@ -45,5 +46,4 @@ public abstract class JoanaTestCase extends TestCase {
         driver = new Driver(config);
         driver.configure();
     }
-
 }

--- a/src/test/java/br/unb/cic/joana/securibench/SecuriBenchTestCase.java
+++ b/src/test/java/br/unb/cic/joana/securibench/SecuriBenchTestCase.java
@@ -41,10 +41,11 @@ public abstract class SecuriBenchTestCase extends JoanaTestCase {
 
         for(Class c: classes) {
             Object instance = c.newInstance();
-            if(instance instanceof MicroTestCase) {
+            if (instance instanceof MicroTestCase) {
                 MicroTestCase microTestCase = (MicroTestCase) instance;
                 int expected = microTestCase.getVulnerabilityCount();
                 int found = 0;
+                
                 try {
                     setUpConfiguration(c.getName() + "." + entryPointMethod());
                     found = driver.execute().size();
@@ -52,7 +53,8 @@ public abstract class SecuriBenchTestCase extends JoanaTestCase {
                     report.add(String.format("- %s failure to execute. Error = %s", c.getName(), e.getMessage()));
                     failure = true;
                 }
-                if(expected == found) {
+
+                if (expected == found) {
                     report.add(String.format(" - %s (ok)", c.getName()));
                 }
                 else {
@@ -70,13 +72,15 @@ public abstract class SecuriBenchTestCase extends JoanaTestCase {
         for(String s: report) {
             System.out.println(s);
         }
-        if(totalOfExpectedVulnerabilities == totalOfVulnerabilitiesFound) {
+
+        if (totalOfExpectedVulnerabilities == totalOfVulnerabilitiesFound) {
             Assert.assertTrue(true);
         }
         else {
             System.err.println(String.format("Error. Expecting %d but found %d warnings.", totalOfExpectedVulnerabilities, totalOfVulnerabilitiesFound));
         }
-        if(failure) {
+
+        if (failure) {
             System.err.println("We found errors in the Joana execution or configuration.");
         }
     }

--- a/src/test/java/br/unb/cic/joana/securibench/SecuriBenchTestCase.java
+++ b/src/test/java/br/unb/cic/joana/securibench/SecuriBenchTestCase.java
@@ -39,33 +39,33 @@ public abstract class SecuriBenchTestCase extends JoanaTestCase {
 
         boolean failure = false;
 
-        for(Class c: classes) {
+        for (Class c: classes) {
             Object instance = c.newInstance();
-            if (instance instanceof MicroTestCase) {
-                MicroTestCase microTestCase = (MicroTestCase) instance;
-                int expected = microTestCase.getVulnerabilityCount();
-                int found = 0;
-                
-                try {
-                    setUpConfiguration(c.getName() + "." + entryPointMethod());
-                    found = driver.execute().size();
-                } catch(Throwable e) {
-                    report.add(String.format("- %s failure to execute. Error = %s", c.getName(), e.getMessage()));
-                    failure = true;
-                }
 
-                if (expected == found) {
-                    report.add(String.format(" - %s (ok)", c.getName()));
-                }
-                else {
-                    report.add(String.format("- %s error. Expecting %d but found %d vulnerabilities.", c.getName(), expected, found));
-                }
-                totalOfExpectedVulnerabilities += expected;
-                totalOfVulnerabilitiesFound += found;
-            }
-            else {
+            if (! (instance instanceof MicroTestCase)) {
                 throw new RuntimeException("Could not instantiate " + c.getName() + " as a MicroTestCase");
             }
+
+            MicroTestCase microTestCase = (MicroTestCase) instance;
+            int expected = microTestCase.getVulnerabilityCount();
+            int found = 0;
+            
+            try {
+                setUpConfiguration(c.getName() + "." + entryPointMethod());
+                found = driver.execute().size();
+            } catch(Throwable e) {
+                report.add(String.format("- %s failure to execute. Error = %s", c.getName(), e.getMessage()));
+                failure = true;
+            }
+
+            if (expected == found) {
+                report.add(String.format(" - %s (ok)", c.getName()));
+            }
+            else {
+                report.add(String.format("- %s error. Expecting %d but found %d vulnerabilities.", c.getName(), expected, found));
+            }
+            totalOfExpectedVulnerabilities += expected;
+            totalOfVulnerabilitiesFound += found;
         }
 
         Collections.sort(report);

--- a/src/test/java/br/unb/cic/joana/securibench/micro/suite/ArrayTestSuite.java
+++ b/src/test/java/br/unb/cic/joana/securibench/micro/suite/ArrayTestSuite.java
@@ -1,0 +1,16 @@
+package br.unb.cic.joana.securibench.micro.suite;
+
+import br.unb.cic.joana.securibench.SecuriBenchTestCase;
+
+public class ArrayTestSuite extends SecuriBenchTestCase {
+
+    @Override
+    public String basePackage() {
+        return "securibench.micro.arrays";
+    }
+
+    @Override
+    public String entryPointMethod() {
+        return "doGet(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V";
+    }
+}

--- a/src/test/java/br/unb/cic/joana/securibench/micro/suite/CollectionTestSuite.java
+++ b/src/test/java/br/unb/cic/joana/securibench/micro/suite/CollectionTestSuite.java
@@ -1,0 +1,16 @@
+package br.unb.cic.joana.securibench.micro.suite;
+
+import br.unb.cic.joana.securibench.SecuriBenchTestCase;
+
+public class CollectionTestSuite extends SecuriBenchTestCase {
+
+    @Override
+    public String basePackage() {
+        return "securibench.micro.collections";
+    }
+
+    @Override
+    public String entryPointMethod() {
+        return "doGet(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V";
+    }
+}

--- a/src/test/java/br/unb/cic/joana/securibench/micro/suite/DatastructureTestSuite.java
+++ b/src/test/java/br/unb/cic/joana/securibench/micro/suite/DatastructureTestSuite.java
@@ -1,0 +1,16 @@
+package br.unb.cic.joana.securibench.micro.suite;
+
+import br.unb.cic.joana.securibench.SecuriBenchTestCase;
+
+public class DatastructureTestSuite extends SecuriBenchTestCase {
+
+    @Override
+    public String basePackage() {
+        return "securibench.micro.datastructures";
+    }
+
+    @Override
+    public String entryPointMethod() {
+        return "doGet(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V";
+    }
+}

--- a/src/test/java/br/unb/cic/joana/securibench/micro/suite/FactoryTestSuite.java
+++ b/src/test/java/br/unb/cic/joana/securibench/micro/suite/FactoryTestSuite.java
@@ -1,0 +1,16 @@
+package br.unb.cic.joana.securibench.micro.suite;
+
+import br.unb.cic.joana.securibench.SecuriBenchTestCase;
+
+public class FactoryTestSuite extends SecuriBenchTestCase {
+
+    @Override
+    public String basePackage() {
+        return "securibench.micro.factories";
+    }
+
+    @Override
+    public String entryPointMethod() {
+        return "doGet(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V";
+    }
+}

--- a/src/test/java/br/unb/cic/joana/securibench/micro/suite/InterTestSuite.java
+++ b/src/test/java/br/unb/cic/joana/securibench/micro/suite/InterTestSuite.java
@@ -1,0 +1,16 @@
+package br.unb.cic.joana.securibench.micro.suite;
+
+import br.unb.cic.joana.securibench.SecuriBenchTestCase;
+
+public class InterTestSuite extends SecuriBenchTestCase {
+
+    @Override
+    public String basePackage() {
+        return "securibench.micro.inter";
+    }
+
+    @Override
+    public String entryPointMethod() {
+        return "doGet(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V";
+    }
+}

--- a/src/test/java/br/unb/cic/joana/securibench/micro/suite/SessionTestSuite.java
+++ b/src/test/java/br/unb/cic/joana/securibench/micro/suite/SessionTestSuite.java
@@ -1,0 +1,16 @@
+package br.unb.cic.joana.securibench.micro.suite;
+
+import br.unb.cic.joana.securibench.SecuriBenchTestCase;
+
+public class SessionTestSuite extends SecuriBenchTestCase {
+
+    @Override
+    public String basePackage() {
+        return "securibench.micro.session";
+    }
+
+    @Override
+    public String entryPointMethod() {
+        return "doGet(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V";
+    }
+}

--- a/src/test/java/br/unb/cic/joana/securibench/micro/suite/StrongUpdateTestSuite.java
+++ b/src/test/java/br/unb/cic/joana/securibench/micro/suite/StrongUpdateTestSuite.java
@@ -1,0 +1,16 @@
+package br.unb.cic.joana.securibench.micro.suite;
+
+import br.unb.cic.joana.securibench.SecuriBenchTestCase;
+
+public class StrongUpdateTestSuite extends SecuriBenchTestCase {
+
+    @Override
+    public String basePackage() {
+        return "securibench.micro.strong_updates";
+    }
+
+    @Override
+    public String entryPointMethod() {
+        return "doGet(Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)V";
+    }
+}

--- a/src/test/resources/securibench.yaml
+++ b/src/test/resources/securibench.yaml
@@ -1,7 +1,7 @@
 applicationClassPath: ignore
 entryPointMethod: ignore
 thirdPartyLibraries:
-  - ~/.m2/repository/javax/servlet-api/2.5/servlet-api-2.5.jar
+  - ~/.m2/repository/javax/servlet/javax.servlet-api/3.0.1/javax.servlet-api-3.0.1.jar
 sourceMethods:
   - javax.servlet.http.HttpServletRequest.getParameter(Ljava/lang/String;)Ljava/lang/String;
   - javax.servlet.ServletRequestWrapper.getParameter(Ljava/lang/String;)Ljava/lang/String;


### PR DESCRIPTION
- Create missing tests;
- Set up right thirdPartyLibraries according to project's POM;
- Refactor class SecuriBenchTestCase to use "early return".